### PR TITLE
docs: update eks-3 keda config

### DIFF
--- a/examples/multi-cluster-shared-vpc/README.md
+++ b/examples/multi-cluster-shared-vpc/README.md
@@ -27,9 +27,18 @@ Shared **tfvars** (one block for all three): `argocd_idc_instance_arn`, `argocd_
 
 The **Fargate** cluster has no **Pod Identity** agent. For the AWS Load Balancer Controller (or any addon that needs AWS API access), use **IRSA** only.
 
+## Fargate cluster: IRSA (ALB controller + SQS / KEDA)
+
+[EKS Pod Identity is not supported for pods on Fargate](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html). This example uses **IRSA** (OIDC) for AWS API access from Fargate workloads where needed.
+
+- **AWS Load Balancer Controller:** `aws_load_balancer_controller_identity_type = "irsa"`. After apply, use `terraform output -raw fargate_aws_load_balancer_controller_role_arn` for the controller ServiceAccount `eks.amazonaws.com/role-arn` (see `kube-infra` ALB overlay for eks-3).
+- **Celery SQS + KEDA:** `enable_sqs_access = true` with **`sqs_identity_type = "irsa"`** on the Fargate module only. Classic and Auto Mode clusters keep **`sqs_identity_type = "pod_identity"`**. After apply, use **`terraform output -json fargate_sqs_role_arns`** — keys **`celery/celery-workload`** and **`keda/keda-operator`**. Annotate those Kubernetes ServiceAccounts in **kube-devops-apps** (celery eks-3 overlay) and **kube-infra** (KEDA eks-3 overlay) with `eks.amazonaws.com/role-arn: <arn>`. IAM role names follow `terraform-aws-eks-basic/sqs-iam.tf`: `<cluster_name>-sqs-<namespace>-<sa>-role` with `/` in the map key replaced by `-` (e.g. `eks-3-sqs-celery-celery-workload-role` when `cluster_names.fargate = "eks-3"`).
+
+The **EKS Pod Identity Agent** add-on remains enabled on the Fargate cluster for consistency with other examples; it does **not** grant Pod Identity credentials to Fargate pods.
+
 This example:
 
-- Adds **Fargate profiles** for `kube-system`, `aws-load-balancer-controller`, `gatekeeper-system`, **`keda`**, and the **default app** namespace (`fargate_namespace`, e.g. `app`).
+- Adds **Fargate profiles** for `kube-system`, `aws-load-balancer-controller`, `gatekeeper-system`, **`keda`**, **`workload_sqs`**, and the **default app** namespace (`fargate_namespace`, e.g. `app`). Profile selectors are in `main.tf`.
 - When **`argocd_idc_instance_arn` is set**, merges an **`argocd`** profile so the EKS **Argo CD** capability (namespace `argocd`) can schedule on this Fargate-only cluster.
 - Sets `enable_aws_load_balancer_controller = true`, `aws_load_balancer_controller_identity_type = "irsa"`.
 
@@ -60,3 +69,4 @@ aws eks update-kubeconfig --name $(terraform output -raw automode_cluster_name) 
 
 - `classic_argocd_connection_ids`, `fargate_argocd_connection_ids`, `automode_argocd_connection_ids` — maps keyed by connection `name` (e.g. `github-eks-1`).
 - `fargate_aws_load_balancer_controller_role_arn` — IRSA role for ALB controller on the Fargate cluster.
+- `fargate_sqs_role_arns` — map of IRSA role ARNs for SQS (`celery/celery-workload`, `keda/keda-operator`) on the Fargate cluster.

--- a/examples/multi-cluster-shared-vpc/main.tf
+++ b/examples/multi-cluster-shared-vpc/main.tf
@@ -17,6 +17,8 @@ provider "aws" {
   region = var.aws_region
 }
 
+data "aws_caller_identity" "current" {}
+
 # Fargate and Auto Mode cluster subnet tags merged into vpc tags so aws_subnet owns them.
 # aws_ec2_tag would conflict with aws_subnet in AWS provider v6 (both fighting over the same tag keys).
 #
@@ -28,6 +30,27 @@ locals {
     "kubernetes.io/cluster/${var.cluster_names.fargate}"  = "shared"
     "kubernetes.io/cluster/${var.cluster_names.automode}" = "shared"
   })
+
+  ack_kro_capabilities = {
+    ack = {
+      iam_policy_arns = {
+        sqs = "arn:aws:iam::aws:policy/AmazonSQSFullAccess"
+      }
+    }
+    kro = {}
+  }
+
+  sqs_access_queue_arn = {
+    classic  = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.cluster_names.classic}-celery-jobs"
+    fargate  = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.cluster_names.fargate}-celery-jobs"
+    automode = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.cluster_names.automode}-celery-jobs"
+  }
+
+  sqs_access_queue_arn_dlq = {
+    classic  = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.cluster_names.classic}-celery-jobs-dlq"
+    fargate  = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.cluster_names.fargate}-celery-jobs-dlq"
+    automode = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.cluster_names.automode}-celery-jobs-dlq"
+  }
 }
 
 # One VPC for three clusters. enable_eks_tags adds kubernetes.io/cluster/<classic>=shared via eks_cluster_name.
@@ -101,7 +124,7 @@ module "eks_classic" {
   }
 
   capabilities = merge(
-    { ack = {}, kro = {} },
+    local.ack_kro_capabilities,
     var.argocd_idc_instance_arn != null ? {
       argocd = {
         access_entry_policy_associations = [{
@@ -129,6 +152,26 @@ module "eks_classic" {
     { namespace = "sm-operator-system", service_account = "awssm-sync" },
   ]
   secrets_manager_secret_name_prefixes = ["bitwarden/sm-operator"]
+
+  enable_sqs_access = true
+  sqs_identity_type = "pod_identity"
+  sqs_access = [
+    {
+      namespace       = "celery"
+      service_account = "celery-workload"
+      queue_arns = [
+        local.sqs_access_queue_arn.classic,
+        local.sqs_access_queue_arn_dlq.classic,
+      ]
+      mode = "consumer"
+    },
+    {
+      namespace       = "keda"
+      service_account = "keda-operator"
+      queue_arns      = [local.sqs_access_queue_arn.classic]
+      mode            = "read_only"
+    },
+  ]
 
   tags = var.tags
 }
@@ -159,6 +202,10 @@ module "eks_fargate" {
       before_compute = true
       addon_version  = "v1.21.1-eksbuild.7"
     }
+    eks-pod-identity-agent = {
+      before_compute = true
+      addon_version  = "v1.3.10-eksbuild.2"
+    }
   }
 
   # Per-namespace profiles (Fargate matches namespace only, not labels, unless you add selectors).
@@ -182,6 +229,10 @@ module "eks_fargate" {
         selectors  = [{ namespace = "keda" }]
         subnet_ids = module.vpc.private_subnet_ids
       }
+      workload_sqs = {
+        selectors  = [{ namespace = "celery" }]
+        subnet_ids = module.vpc.private_subnet_ids
+      }
       default = {
         selectors  = [{ namespace = var.fargate_namespace }]
         subnet_ids = module.vpc.private_subnet_ids
@@ -199,7 +250,7 @@ module "eks_fargate" {
   aws_load_balancer_controller_identity_type = "irsa"
 
   capabilities = merge(
-    { ack = {}, kro = {} },
+    local.ack_kro_capabilities,
     var.argocd_idc_instance_arn != null ? {
       argocd = {
         access_entry_policy_associations = [{
@@ -217,6 +268,28 @@ module "eks_fargate" {
       }
     } : {}
   )
+
+  # Fargate: EKS Pod Identity is not supported for pods on Fargate (AWS). Use IRSA for SQS roles
+  # and annotate ServiceAccounts (kube-devops-apps celery SA; kube-infra keda-operator SA on eks-3).
+  enable_sqs_access = true
+  sqs_identity_type = "irsa"
+  sqs_access = [
+    {
+      namespace       = "celery"
+      service_account = "celery-workload"
+      queue_arns = [
+        local.sqs_access_queue_arn.fargate,
+        local.sqs_access_queue_arn_dlq.fargate,
+      ]
+      mode = "consumer"
+    },
+    {
+      namespace       = "keda"
+      service_account = "keda-operator"
+      queue_arns      = [local.sqs_access_queue_arn.fargate]
+      mode            = "read_only"
+    },
+  ]
 
   tags = var.tags
 }
@@ -243,7 +316,7 @@ module "eks_automode" {
   addons              = {}
 
   capabilities = merge(
-    { ack = {}, kro = {} },
+    local.ack_kro_capabilities,
     var.argocd_idc_instance_arn != null ? {
       argocd = {
         access_entry_policy_associations = [{
@@ -271,6 +344,26 @@ module "eks_automode" {
     { namespace = "sm-operator-system", service_account = "awssm-sync" },
   ]
   secrets_manager_secret_name_prefixes = ["bitwarden/sm-operator"]
+
+  enable_sqs_access = true
+  sqs_identity_type = "pod_identity"
+  sqs_access = [
+    {
+      namespace       = "celery"
+      service_account = "celery-workload"
+      queue_arns = [
+        local.sqs_access_queue_arn.automode,
+        local.sqs_access_queue_arn_dlq.automode,
+      ]
+      mode = "consumer"
+    },
+    {
+      namespace       = "keda"
+      service_account = "keda-operator"
+      queue_arns      = [local.sqs_access_queue_arn.automode]
+      mode            = "read_only"
+    },
+  ]
 
   tags = var.tags
 }

--- a/examples/multi-cluster-shared-vpc/outputs.tf
+++ b/examples/multi-cluster-shared-vpc/outputs.tf
@@ -56,6 +56,11 @@ output "fargate_aws_load_balancer_controller_role_arn" {
   value       = module.eks_fargate.aws_load_balancer_controller_role_arn
 }
 
+output "fargate_sqs_role_arns" {
+  description = "IRSA role ARNs for SQS (celery consumer + KEDA metrics) on the Fargate cluster when sqs_identity_type = irsa"
+  value       = module.eks_fargate.sqs_role_arns
+}
+
 output "fargate_profiles" {
   value = module.eks_fargate.fargate_profiles
 }


### PR DESCRIPTION
switches from pod identity to irsa as the only supported auth